### PR TITLE
fix-package-exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,12 @@
   "version": "1.1.1",
   "description": "Pseudonimization helper (Blind, Unblind, ...)",
   "type": "module",
-  "exports": "./index.mjs",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.mjs"
+    }
+  },
   "types": "./index.d.ts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Angular 20's default moduleResolution: "bundler" requires explicit type exports, causing:  
`TS7016: Could not find a declaration file for module '@smals-belgium-shared/pseudo-helper'`  

Added [Conditional Exports](https://nodejs.org/api/packages.html#conditional-exports) to package.json to properly expose types for bundler module resolution.  

https://nodejs.org/api/packages.html#conditional-exports  
https://www.velopen.com/blog/typescript-npm-package-json-exports/  